### PR TITLE
set cpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,9 @@ The `https_listener_arn` routes traffic to ArchivesSpace.
 
 #### Cpu
 
-This only applies to Fargate containers.
-
 ```hcl
 cpu = 1024 # 1 v/cpu default
+cpu = null # don't set a cpu constraint
 ```
 
 #### Memory
@@ -85,7 +84,7 @@ cpu = 1024 # 1 v/cpu default
 ```hcl
 app_memory  = 2048 # specific allocation to the aspace container
 solr_memory = 1024 # specific allocation to the solr container
+task_memory = 3072 # allocation for task (all containers)
 ```
 
-The task definition memory is set to (app_memory + solr_memory). When
-running on Fargate this needs to equal a [compatible value](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html).
+When running on Fargate the `task_memory` needs to equal a [compatible value](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html).

--- a/ecs.tf
+++ b/ecs.tf
@@ -2,7 +2,7 @@ resource "aws_ecs_task_definition" "this" {
   family                   = var.name
   network_mode             = var.network_mode
   requires_compatibilities = var.requires_compatibilities
-  cpu                      = var.capacity_provider == "FARGATE" ? var.cpu : null
+  cpu                      = var.cpu
   memory                   = local.memory
   execution_role_arn       = aws_iam_role.this.arn
   task_role_arn            = aws_iam_role.this.arn

--- a/variables.tf
+++ b/variables.tf
@@ -47,7 +47,7 @@ variable "cluster_id" {
 
 variable "cpu" {
   default     = 1024
-  description = "Task level CPU allocation (applies only when using Fargate)"
+  description = "Task level CPU allocation"
 }
 
 variable "custom_env_cfg" {


### PR DESCRIPTION
- Redo memory, use explicit assignment for app
- Listener priority cfg not required with proxy addition (#6)
- Add links for non-awsvpc container networking (#10)
- Update docs, use tg name_prefix & add links on bridge
- Use dash with tg prefix
- Expose task memory as var for full control
- Add custom env to taskdef & set more envvars
- Don't restrict cpu alloc to fargate
