### PR TITLE
solr file limit

### DIFF
--- a/task-definition/archivesspace.json.tpl
+++ b/task-definition/archivesspace.json.tpl
@@ -256,6 +256,13 @@
         "containerPath": "/var/solr"
       }
     ],
+    "ulimits": [
+      {
+        "name": "nofile",
+        "softLimit": 65000,
+        "hardLimit": 65000
+      }
+    ],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {


### PR DESCRIPTION
- Redo memory, use explicit assignment for app
- Listener priority cfg not required with proxy addition (#6)
- Add links for non-awsvpc container networking (#10)
- Update docs, use tg name_prefix & add links on bridge
- Use dash with tg prefix
- Expose task memory as var for full control
- Add custom env to taskdef & set more envvars
- Don't restrict cpu alloc to fargate
- Update example services doc
- Add examples services url
- Increase open file limit per solr recommendations
