### PR TITLE
ddb access

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -24,6 +24,7 @@ resource "aws_iam_role" "this" {
 EOF
 
   managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
     "arn:aws:iam::aws:policy/AmazonECS_FullAccess",
     "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role",


### PR DESCRIPTION
- Redo memory, use explicit assignment for app
- Listener priority cfg not required with proxy addition (#6)
- Add links for non-awsvpc container networking (#10)
- Update docs, use tg name_prefix & add links on bridge
- Use dash with tg prefix
- Expose task memory as var for full control
- Add custom env to taskdef & set more envvars
- Don't restrict cpu alloc to fargate
- Update example services doc
- Add examples services url
- Increase open file limit per solr recommendations
- Support container ddb access
