### PR TITLE
nginx api whitelist

### DIFF
--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -1,0 +1,29 @@
+name: Build proxy docker image
+
+on:
+  push:
+    branches:
+      - "main"
+      - "test"
+    paths:
+      - "docker/**"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: docker
+          push: true
+          tags: lyrasis/aspace-proxy:${{ github.ref_name == 'main' && 'latest' || github.ref_name }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ ENV API_PREFIX="/api/" \
     PROXY_TYPE="single" \
     PUBLIC_NAME="" \
     PUBLIC_PREFIX="/" \
+    REAL_IP_CIDR="10.0.0.0/16" \
     STAFF_NAME="" \
     STAFF_PREFIX="/" \
     UPSTREAM_HOST="localhost"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,12 @@
 FROM --platform=linux/amd64 nginx
 
-ENV API_PREFIX="/api/" \
+ENV API_IPS_ALLOWED="allow 0.0.0.0/0" \
+    API_PREFIX="/api/" \
     OAI_PREFIX="/oai" \
     PROXY_TYPE="single" \
     PUBLIC_NAME="" \
     PUBLIC_PREFIX="/" \
+    PUI_IPS_ALLOWED="allow 0.0.0.0/0" \
     REAL_IP_CIDR="10.0.0.0/16" \
     STAFF_NAME="" \
     STAFF_PREFIX="/" \

--- a/docker/common-config
+++ b/docker/common-config
@@ -7,6 +7,9 @@ client_max_body_size 16M;
 access_log /dev/stdout;
 error_log  /dev/stdout info;
 
+real_ip_header          X-Forwarded-For;
+set_real_ip_from        10.0.0.0/16;
+
 proxy_buffer_size       128k;
 proxy_buffers           4 256k;
 proxy_busy_buffers_size 256k;

--- a/docker/common-config
+++ b/docker/common-config
@@ -7,8 +7,8 @@ client_max_body_size 16M;
 access_log /dev/stdout;
 error_log  /dev/stdout info;
 
-real_ip_header          X-Forwarded-For;
-set_real_ip_from        10.0.0.0/16;
+real_ip_header    X-Forwarded-For;
+real_ip_recursive on;
 
 proxy_buffer_size       128k;
 proxy_buffers           4 256k;

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,11 +5,13 @@ services:
     build:
       context: .
     environment:
+      API_IPS_ALLOWED: "allow 0.0.0.0/0"
       API_PREFIX: "/api/"
       OAI_PREFIX: "/oai"
       PROXY_TYPE: "single"
       PUBLIC_NAME: "archivesspace-ex-complete.lyrtech.org"
       PUBLIC_PREFIX: "/"
+      PUI_IPS_ALLOWED: "allow 0.0.0.0/0"
       REAL_IP_CIDR: "10.0.0.0/16"
       STAFF_NAME: "archivesspace-ex-complete.lyrtech.org"
       STAFF_PREFIX: "/staff/"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       PROXY_TYPE: "single"
       PUBLIC_NAME: "archivesspace-ex-complete.lyrtech.org"
       PUBLIC_PREFIX: "/"
+      REAL_IP_CIDR: "10.0.0.0/16"
       STAFF_NAME: "archivesspace-ex-complete.lyrtech.org"
       STAFF_PREFIX: "/staff/"
       UPSTREAM_HOST: ${UPSTREAM_HOST:-localhost}

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-envsubst '${API_PREFIX} ${OAI_PREFIX} ${PUBLIC_NAME} ${PUBLIC_PREFIX} ${REAL_IP_CIDR} ${STAFF_NAME} ${STAFF_PREFIX} ${UPSTREAM_HOST}' \
+envsubst '${API_IPS_ALLOWED} ${API_PREFIX} ${OAI_PREFIX} ${PUBLIC_NAME} ${PUBLIC_PREFIX} ${PUI_IPS_ALLOWED} ${REAL_IP_CIDR} ${STAFF_NAME} ${STAFF_PREFIX} ${UPSTREAM_HOST}' \
   < /etc/nginx/conf.d/$PROXY_TYPE-domain.conf.template > /etc/nginx/conf.d/default.conf
 
 exec "$@"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-envsubst '${API_PREFIX} ${OAI_PREFIX} ${PUBLIC_NAME} ${PUBLIC_PREFIX} ${STAFF_NAME} ${STAFF_PREFIX} ${UPSTREAM_HOST}' \
+envsubst '${API_PREFIX} ${OAI_PREFIX} ${PUBLIC_NAME} ${PUBLIC_PREFIX} ${REAL_IP_CIDR} ${STAFF_NAME} ${STAFF_PREFIX} ${UPSTREAM_HOST}' \
   < /etc/nginx/conf.d/$PROXY_TYPE-domain.conf.template > /etc/nginx/conf.d/default.conf
 
 exec "$@"

--- a/docker/templates/multi-domain.conf.template
+++ b/docker/templates/multi-domain.conf.template
@@ -20,10 +20,14 @@ server {
   include /etc/nginx/common-config;
 
   location ${PUBLIC_PREFIX} {
+    ${PUI_IPS_ALLOWED};
+    deny all;
     proxy_pass http://app_public;
   }
 
   location ${OAI_PREFIX} {
+    ${PUI_IPS_ALLOWED};
+    deny all;
     proxy_pass http://app_oai/;
   }
 }
@@ -38,6 +42,8 @@ server {
   }
 
   location ${API_PREFIX} {
+    ${API_IPS_ALLOWED};
+    deny all;
     proxy_pass http://app_api/;
   }
 }

--- a/docker/templates/multi-domain.conf.template
+++ b/docker/templates/multi-domain.conf.template
@@ -16,6 +16,7 @@ upstream app_staff {
 
 server {
   server_name ${PUBLIC_NAME};
+  set_real_ip_from ${REAL_IP_CIDR};
   include /etc/nginx/common-config;
 
   location ${PUBLIC_PREFIX} {
@@ -29,6 +30,7 @@ server {
 
 server {
   server_name ${STAFF_NAME};
+  set_real_ip_from ${REAL_IP_CIDR};
   include /etc/nginx/common-config;
 
   location ${STAFF_PREFIX} {

--- a/docker/templates/single-domain.conf.template
+++ b/docker/templates/single-domain.conf.template
@@ -16,6 +16,7 @@ upstream app_staff {
 
 server {
   server_name _;
+  set_real_ip_from ${REAL_IP_CIDR};
   include /etc/nginx/common-config;
 
   location ${PUBLIC_PREFIX} {

--- a/docker/templates/single-domain.conf.template
+++ b/docker/templates/single-domain.conf.template
@@ -20,10 +20,14 @@ server {
   include /etc/nginx/common-config;
 
   location ${PUBLIC_PREFIX} {
+    ${PUI_IPS_ALLOWED};
+    deny all;
     proxy_pass http://app_public;
   }
 
   location ${OAI_PREFIX} {
+    ${PUI_IPS_ALLOWED};
+    deny all;
     proxy_pass http://app_oai/;
   }
 
@@ -32,6 +36,8 @@ server {
   }
 
   location ${API_PREFIX} {
+    ${API_IPS_ALLOWED};
+    deny all;
     proxy_pass http://app_api/;
   }
 }

--- a/examples/services/main.tf
+++ b/examples/services/main.tf
@@ -75,6 +75,10 @@ module "archivesspace" {
   requires_compatibilities = ["EC2"]
   target_type              = "ip"
 
+  # ip access
+  app_api_ips_allowed = ["0.0.0.0/0"] # Test with: 127.0.0.1/32
+  app_pui_ips_allowed = ["0.0.0.0/0"] # Test with: 127.0.0.1/32
+
   # custom env & secrets
   custom_env_cfg = {
     "APPCONFIG_EMAIL_DELIVERY_METHOD"     = ":test"

--- a/locals.tf
+++ b/locals.tf
@@ -9,6 +9,7 @@ locals {
   certbot_domains          = join(",", tolist(local.hostnames))
   certbot_email            = var.certbot_email
   certbot_enabled          = var.certbot_enabled ? "true" : "false"
+  certbot_img              = "lyrasis/certbot-acm:latest" # TODO: var
   certbot_port             = 80
   cluster_id               = var.cluster_id
   cpu                      = var.cpu
@@ -32,7 +33,7 @@ locals {
   name                     = var.name
   network_mode             = var.network_mode
   oai_prefix               = local.public_prefix != "/" ? "${local.public_prefix}oai" : "/oai"
-  proxy_img                = "lyrasis/aspace-proxy:latest"
+  proxy_img                = "lyrasis/aspace-proxy:latest" # TODO: var
   proxy_port               = 4000
   proxy_type               = local.public_hostname == local.staff_hostname ? "single" : "multi"
   public_hostname          = var.public_hostname
@@ -65,6 +66,7 @@ locals {
     certbot_domains    = local.certbot_domains
     certbot_email      = local.certbot_email
     certbot_enabled    = local.certbot_enabled
+    certbot_img        = local.certbot_img
     certbot_port       = local.certbot_port
     custom_env_cfg     = local.custom_env_cfg
     custom_secrets_cfg = local.custom_secrets_cfg

--- a/locals.tf
+++ b/locals.tf
@@ -32,6 +32,7 @@ locals {
   name                     = var.name
   network_mode             = var.network_mode
   oai_prefix               = local.public_prefix != "/" ? "${local.public_prefix}oai" : "/oai"
+  proxy_img                = "lyrasis/aspace-proxy:latest"
   proxy_port               = 4000
   proxy_type               = local.public_hostname == local.staff_hostname ? "single" : "multi"
   public_hostname          = var.public_hostname
@@ -78,6 +79,7 @@ locals {
     name               = local.name
     network_mode       = local.network_mode
     oai_prefix         = local.oai_prefix
+    proxy_img          = local.proxy_img
     proxy_port         = local.proxy_port
     proxy_type         = local.proxy_type
     public_hostname    = local.public_hostname

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,5 @@
 locals {
+  api_ips_allowed          = join("; ", formatlist("allow %s", var.app_api_ips_allowed))
   api_prefix               = local.staff_prefix != "/" ? "${local.staff_prefix}/api/" : "/api/"
   app_efs_id               = var.app_efs_id
   app_img                  = var.app_img
@@ -39,6 +40,8 @@ locals {
   public_hostname          = var.public_hostname
   public_prefix            = var.public_prefix
   public_url               = "https://${local.public_hostname}${local.public_prefix}"
+  pui_ips_allowed          = join("; ", formatlist("allow %s", var.app_pui_ips_allowed))
+  real_ip_cidr             = "10.0.0.0/16" # TODO: var
   requires_compatibilities = var.requires_compatibilities
   security_group_id        = var.security_group_id
   solr_efs_id              = var.solr_efs_id
@@ -58,6 +61,7 @@ locals {
   vpc_id                   = var.vpc_id
 
   task_config = {
+    api_ips_allowed    = local.api_ips_allowed
     api_prefix         = local.api_prefix
     app_data           = local.data_volume
     app_img            = local.app_img
@@ -87,6 +91,8 @@ locals {
     public_hostname    = local.public_hostname
     public_prefix      = local.public_prefix
     public_url         = local.public_url
+    pui_ips_allowed    = local.pui_ips_allowed
+    real_ip_cidr       = local.real_ip_cidr
     region             = data.aws_region.current.name
     secret_key         = random_password.secret_key.result
     solr_data          = local.solr_volume

--- a/task-definition/archivesspace.json.tpl
+++ b/task-definition/archivesspace.json.tpl
@@ -74,6 +74,10 @@
     "essential": true,
     "environment": [
       {
+        "name": "API_IPS_ALLOWED",
+        "value": "${api_ips_allowed}"
+      },
+      {
         "name": "API_PREFIX",
         "value": "${api_prefix}"
       },
@@ -92,6 +96,14 @@
       {
         "name": "PUBLIC_PREFIX",
         "value": "${public_prefix}"
+      },
+      {
+        "name": "PUI_IPS_ALLOWED",
+        "value": "${pui_ips_allowed}"
+      },
+      {
+        "name": "REAL_IP_CIDR",
+        "value": "${real_ip_cidr}"
       },
       {
         "name": "STAFF_NAME",

--- a/task-definition/archivesspace.json.tpl
+++ b/task-definition/archivesspace.json.tpl
@@ -1,7 +1,7 @@
 [
   {
     "name": "certbot",
-    "image": "lyrasis/certbot-acm:latest",
+    "image": "${certbot_img}",
     "networkMode": "${network_mode}",
     "essential": true,
     "environment": [

--- a/task-definition/archivesspace.json.tpl
+++ b/task-definition/archivesspace.json.tpl
@@ -69,7 +69,7 @@
   },
   {
     "name": "proxy",
-    "image": "lyrasis/aspace-proxy:latest",
+    "image": "${proxy_img}",
     "networkMode": "${network_mode}",
     "essential": true,
     "environment": [

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ data "aws_ssm_parameter" "db_username" {
   name = var.db_username_param
 }
 
+variable "app_api_ips_allowed" {
+  default     = ["0.0.0.0/0"]
+  description = "List of IP addresses (CIDR notation) allowed access to the API"
+}
+
 variable "app_efs_id" {
   description = "EFS id for ArchivesSpace data directory"
 }
@@ -19,6 +24,11 @@ variable "app_img" {
 variable "app_memory" {
   default     = 2048
   description = "ArchivesSpace memory allocation"
+}
+
+variable "app_pui_ips_allowed" {
+  default     = ["0.0.0.0/0"]
+  description = "List of IP addresses (CIDR notation) allowed access to the PUI"
 }
 
 variable "assign_public_ip" {


### PR DESCRIPTION
- ✨ Moving API whitelist to nginx
- Move hard-coded taskdef certbot img to local
- Use var for real ip from
- Support API and PUI allowed ips in proxy
- Add TF support for api & pui allowed ips
- Add workflow to build proxy image
