### PR TITLE
App mounts only indexer state files, resolves #29

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -16,7 +16,6 @@ locals {
   cpu                      = var.cpu
   custom_env_cfg           = var.custom_env_cfg
   custom_secrets_cfg       = var.custom_secrets_cfg
-  data_volume              = "${local.name}-data"
   db_host                  = var.db_host
   db_migrate               = local.instances == 1 ? true : false
   db_name                  = var.db_name
@@ -28,6 +27,8 @@ locals {
   hostnames                = toset([local.public_hostname, local.staff_hostname])
   http_listener_arn        = var.http_listener_arn
   https_listener_arn       = var.https_listener_arn
+  indexer_pui_state_volume = "${local.name}-indexer_pui_state"
+  indexer_state_volume     = "${local.name}-indexer_state"
   initialize_plugins       = var.initialize_plugins
   instances                = var.instances
   java_opts                = var.java_opts
@@ -65,7 +66,6 @@ locals {
   task_config = {
     api_ips_allowed    = local.api_ips_allowed
     api_prefix         = local.api_prefix
-    app_data           = local.data_volume
     app_img            = local.app_img
     app_memory         = local.app_memory
     certbot_alb_name   = local.certbot_alb_name
@@ -82,6 +82,8 @@ locals {
     db_password_arn    = data.aws_ssm_parameter.db_password.arn
     db_url             = aws_ssm_parameter.db-url.arn
     db_user            = data.aws_ssm_parameter.db_username.value
+    indexer_pui_state  = local.indexer_pui_state_volume
+    indexer_state      = local.indexer_state_volume
     initialize_plugins = local.initialize_plugins
     java_opts          = local.java_opts
     log_group          = aws_cloudwatch_log_group.this.name

--- a/task-definition/archivesspace.json.tpl
+++ b/task-definition/archivesspace.json.tpl
@@ -267,7 +267,14 @@
     "image": "${solr_img}",
     "networkMode": "${network_mode}",
     "essential": true,
-    "command": ["solr-create", "-p", "8983", "-c", "archivesspace", "-d", "archivesspace"],
+    "command": [
+      "/bin/bash",
+      "-c",
+      "${join(" ", [
+        "cp /opt/solr/server/solr/configsets/archivesspace/conf/* /var/solr/data/archivesspace/conf/;",
+        "solr-create -p 8983 -c archivesspace -d archivesspace"
+      ])}"
+    ],
     "environment": [
       {
         "name": "SOLR_JAVA_MEM",

--- a/task-definition/archivesspace.json.tpl
+++ b/task-definition/archivesspace.json.tpl
@@ -230,8 +230,12 @@
     ],
     "mountPoints": [
       {
-        "sourceVolume": "${app_data}",
-        "containerPath": "/archivesspace/data"
+        "sourceVolume": "${indexer_pui_state}",
+        "containerPath": "/archivesspace/data/indexer_pui_state"
+      },
+      {
+        "sourceVolume": "${indexer_state}",
+        "containerPath": "/archivesspace/data/indexer_state"
       }
     ],
     "dependsOn": [


### PR DESCRIPTION
Rather than mount the entire data directory only mount the indexer
state files. It adds one additional access point but otherwise
only mounts the files that are required to be persistent. The other
files / folders are ephemeral.
