### PR TITLE
Use simple solr lock type

### DIFF
--- a/docker/common-config
+++ b/docker/common-config
@@ -25,3 +25,7 @@ location /health {
   default_type text/html;
   return 200 "<!DOCTYPE html><h1>Not too bad!</h1>\n";
 }
+
+location /status {
+  proxy_pass http://app_api/search/repositories?page=1;
+}

--- a/examples/services/main.tf
+++ b/examples/services/main.tf
@@ -52,6 +52,7 @@ module "archivesspace" {
   certbot_enabled    = true
   cluster_id         = data.aws_ecs_cluster.selected.id
   db_host            = var.db_host
+  db_migrate         = true
   db_name            = "archivesspace"
   db_password_param  = var.db_password_param
   db_username_param  = var.db_username_param

--- a/locals.tf
+++ b/locals.tf
@@ -51,6 +51,7 @@ locals {
   security_group_id        = var.security_group_id
   solr_efs_id              = var.solr_efs_id
   solr_img                 = var.solr_img
+  solr_lock_type           = "simple"
   solr_memory              = var.solr_memory
   solr_url                 = "http://${local.network_mode == "awsvpc" ? "localhost" : "solr"}:8983/solr/archivesspace"
   solr_volume              = "${local.name}-solr"
@@ -105,6 +106,7 @@ locals {
     secret_key          = random_password.secret_key.result
     solr_data           = local.solr_volume
     solr_img            = local.solr_img
+    solr_lock_type      = local.solr_lock_type
     solr_memory         = local.solr_memory
     solr_url            = local.solr_url
     staff_hostname      = local.staff_hostname

--- a/task-definition/archivesspace.json.tpl
+++ b/task-definition/archivesspace.json.tpl
@@ -282,11 +282,7 @@
     "environment": [
       {
         "name": "SOLR_JAVA_MEM",
-        "value": "-Xms${solr_memory}m -Xmx${solr_memory}m"
-      },
-      {
-        "name": "SOLR_OPTS",
-        "value": "-Dsolr.lock.type=${solr_lock_type}"
+        "value": "-Xms${solr_memory}m -Xmx${solr_memory}m -Dsolr.lock.type=${solr_lock_type}"
       }
     ],
     "mountPoints": [

--- a/task-definition/archivesspace.json.tpl
+++ b/task-definition/archivesspace.json.tpl
@@ -283,6 +283,10 @@
       {
         "name": "SOLR_JAVA_MEM",
         "value": "-Xms${solr_memory}m -Xmx${solr_memory}m"
+      },
+      {
+        "name": "SOLR_OPTS",
+        "value": "-Dsolr.lock.type=${solr_lock_type}"
       }
     ],
     "mountPoints": [

--- a/variables.tf
+++ b/variables.tf
@@ -74,6 +74,11 @@ variable "db_host" {
   description = "ArchivesSpace db host"
 }
 
+variable "db_migrate" {
+  default     = false
+  description = "Run the ArchivesSpace database migration script on startup"
+}
+
 variable "db_name" {
   description = "ArchivesSpace db name"
 }


### PR DESCRIPTION
The default (native) is not recommended for environments where
multiple solr instances may access a single index:

https://solr.apache.org/guide/8_1/indexconfig-in-solrconfig.html

This can happen with Solr running in ECS.
