### PR TITLE
Update public prefix to "public" when pui disabled

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -40,7 +40,7 @@ locals {
   proxy_health_path        = local.db_migrate && !local.db_migrate_healthcheck ? "/health" : "/status" # "/health" is a canned response, always returning http status 200
   public_hostname          = local.public_enabled ? var.public_hostname : local.staff_hostname
   public_ips_allowed       = join("; ", formatlist("allow %s", var.public_ips_allowed))
-  public_prefix            = var.public_prefix
+  public_prefix            = local.public_enabled ? var.public_prefix : "/public/"
   public_url               = trimsuffix("https://${local.public_hostname}${local.public_prefix}", "/")
   real_ip_cidr             = "10.0.0.0/16" # TODO: var
   requires_compatibilities = var.requires_compatibilities


### PR DESCRIPTION
This creates a usable looking prefix for when PUI is disabled but still want access to OAI. Setting it to "public" avoids an nginx config issue when using "/" which is likely to clash with the staff prefix for single domain sites (which will be the case when pui is disabled for sure).