### PR TITLE
fixes missing fail to redirect on pui

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -3,12 +3,15 @@ set -eu
 
 if [ "$PUBLIC_PREFIX" != "/" ]; then
   REDIRECT_BLOCK="location = ${PUBLIC_PREFIX%/} { return 301 \$scheme://\$host$PUBLIC_PREFIX\$is_args\$args; }"
+  ROOT_REDIRECT_BLOCK="location = / { return 301 \$scheme://\$host$PUBLIC_PREFIX; }"
 else
   REDIRECT_BLOCK=""
+  ROOT_REDIRECT_BLOCK=""
 fi
 
 export REDIRECT_BLOCK
+export ROOT_REDIRECT_BLOCK
 
-envsubst '${API_IPS_ALLOWED} ${API_PREFIX} ${OAI_PREFIX} ${PUBLIC_NAME} ${PUBLIC_PREFIX} ${PUI_IPS_ALLOWED} ${REAL_IP_CIDR} ${STAFF_NAME} ${STAFF_PREFIX} ${SUI_IPS_ALLOWED} ${UPSTREAM_HOST} ${REDIRECT_BLOCK}' \
+envsubst '${API_IPS_ALLOWED} ${API_PREFIX} ${OAI_PREFIX} ${PUBLIC_NAME} ${PUBLIC_PREFIX} ${PUI_IPS_ALLOWED} ${REAL_IP_CIDR} ${STAFF_NAME} ${STAFF_PREFIX} ${SUI_IPS_ALLOWED} ${UPSTREAM_HOST} ${REDIRECT_BLOCK} ${ROOT_REDIRECT_BLOCK}' \
   < /etc/nginx/conf.d/$PROXY_TYPE-domain.conf.template > /etc/nginx/conf.d/default.conf
 exec "$@"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env sh
 set -eu
 
-envsubst '${API_IPS_ALLOWED} ${API_PREFIX} ${OAI_PREFIX} ${PUBLIC_NAME} ${PUBLIC_PREFIX} ${PUI_IPS_ALLOWED} ${REAL_IP_CIDR} ${STAFF_NAME} ${STAFF_PREFIX} ${SUI_IPS_ALLOWED} ${UPSTREAM_HOST}' \
-  < /etc/nginx/conf.d/$PROXY_TYPE-domain.conf.template > /etc/nginx/conf.d/default.conf
+if [ "$PUBLIC_PREFIX" != "/" ]; then
+  REDIRECT_BLOCK="location = ${PUBLIC_PREFIX%/} { return 301 \$scheme://\$host$PUBLIC_PREFIX\$is_args\$args; }"
+else
+  REDIRECT_BLOCK=""
+fi
 
+export REDIRECT_BLOCK
+
+envsubst '${API_IPS_ALLOWED} ${API_PREFIX} ${OAI_PREFIX} ${PUBLIC_NAME} ${PUBLIC_PREFIX} ${PUI_IPS_ALLOWED} ${REAL_IP_CIDR} ${STAFF_NAME} ${STAFF_PREFIX} ${SUI_IPS_ALLOWED} ${UPSTREAM_HOST} ${REDIRECT_BLOCK}' \
+  < /etc/nginx/conf.d/$PROXY_TYPE-domain.conf.template > /etc/nginx/conf.d/default.conf
 exec "$@"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,8 +2,8 @@
 set -eu
 
 if [ "$PUBLIC_PREFIX" != "/" ]; then
-  REDIRECT_BLOCK="location = ${PUBLIC_PREFIX%/} { return 301 \$scheme://\$host$PUBLIC_PREFIX\$is_args\$args; }"
-  ROOT_REDIRECT_BLOCK="location = / { return 301 \$scheme://\$host$PUBLIC_PREFIX; }"
+  REDIRECT_BLOCK="rewrite ^${PUBLIC_PREFIX%/}$ $PUBLIC_PREFIX permanent;"
+  ROOT_REDIRECT_BLOCK="rewrite ^/$ $PUBLIC_PREFIX permanent;"
 else
   REDIRECT_BLOCK=""
   ROOT_REDIRECT_BLOCK=""

--- a/docker/templates/multi-domain.conf.template
+++ b/docker/templates/multi-domain.conf.template
@@ -25,6 +25,8 @@ server {
 
   ${REDIRECT_BLOCK}
 
+  ${ROOT_REDIRECT_BLOCK}
+
   location ${PUBLIC_PREFIX} {
     ${PUI_IPS_ALLOWED};
     deny all;

--- a/docker/templates/multi-domain.conf.template
+++ b/docker/templates/multi-domain.conf.template
@@ -23,6 +23,8 @@ server {
   set_real_ip_from ${REAL_IP_CIDR};
   include /etc/nginx/common-config;
 
+  ${REDIRECT_BLOCK}
+
   location ${PUBLIC_PREFIX} {
     ${PUI_IPS_ALLOWED};
     deny all;

--- a/docker/templates/single-domain.conf.template
+++ b/docker/templates/single-domain.conf.template
@@ -25,6 +25,8 @@ server {
 
   ${REDIRECT_BLOCK}
 
+  ${ROOT_REDIRECT_BLOCK}
+
   location ${PUBLIC_PREFIX} {
     ${PUI_IPS_ALLOWED};
     deny all;

--- a/docker/templates/single-domain.conf.template
+++ b/docker/templates/single-domain.conf.template
@@ -23,6 +23,8 @@ server {
   set_real_ip_from ${REAL_IP_CIDR};
   include /etc/nginx/common-config;
 
+  ${REDIRECT_BLOCK}
+
   location ${PUBLIC_PREFIX} {
     ${PUI_IPS_ALLOWED};
     deny all;


### PR DESCRIPTION
https://3.basecamp.com/3410311/buckets/46717787/todos/9738952499#__recording_9818875307

_"I apologize if this is something basic but the url only works with the final forward slash (/archives/) and it seems to be affecting many of our internal links (and my own bookmark, so likely some others) I am happy to update anything on our end but is there a way that https://data.library.amnh.org/archives could work too? Or is this an issue on our end that I should reach out to Paul DelongPaul  or Lawrence LevinsonLawrence about"_

I have an image testing now

```
docker compose build --no-cache
docker tag docker-aspace-proxy lyrasis/aspace-proxy:pui-slash
docker push lyrasis/aspace-proxy:pui-slash
```

It's running on QA. https://asqa.lyrtech.org/blakez  and we did some testing and seems to work fine

```
diff --git a/sites/archivesspace/config/qa.tfvars b/sites/archivesspace/config/qa.tfvars
index d769f8d8..cca5f0d4 100644
--- a/sites/archivesspace/config/qa.tfvars
+++ b/sites/archivesspace/config/qa.tfvars
@@ -13,8 +13,9 @@ instance_spec      = "small"
 lb_name            = "aspace-hosting-production-lb-s1"
 oai_enabled        = false
 org_name           = "Lyrasis Hosting Team"
+proxy_img           = "lyrasis/aspace-proxy:pui-slash"
 public_hostname    = "asqa.lyrtech.org"
-public_prefix      = "/"
+public_prefix      = "/blakez/"
 scheduled_restart  = true
 site               = "qa"
 solr_ecs_enabled   = false
```