### PR TITLE
adding some nginx defensive moves

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ ENV API_IPS_ALLOWED="allow 0.0.0.0/0" \
     API_PREFIX="/api/" \
     OAI_PREFIX="/oai" \
     PROXY_TYPE="single" \
+    PUBLIC_ENABLED="false" \
     PUBLIC_NAME="" \
     PUBLIC_PREFIX="/" \
     PUI_IPS_ALLOWED="allow 0.0.0.0/0" \

--- a/docker/common-config
+++ b/docker/common-config
@@ -45,6 +45,13 @@ server_tokens off;
 tcp_nopush  on;
 tcp_nodelay on;
 
+proxy_cookie_flags ~ ".*" samesite=lax secure;
+
+location ^~ /_ {
+  return 403;
+  access_log off;
+}
+
 location /health {
   default_type text/html;
   return 200 "<!DOCTYPE html><h1>Not too bad!</h1>\n";

--- a/docker/common-config
+++ b/docker/common-config
@@ -38,6 +38,12 @@ proxy_set_header        X-Real-IP          $remote_addr;
 real_ip_header    X-Forwarded-For;
 real_ip_recursive on;
 
+# TLS is terminated upstream (ALB) and nginx listens on plain HTTP:4000, so
+# absolute redirects would leak the wrong scheme/port (http://host:4000/...)
+# and time out. Emit relative redirects to keep clients on the https origin.
+# fixes /public timeouts
+absolute_redirect off;
+
 send_timeout  300s;
 sendfile      on;
 server_tokens off;

--- a/docker/common-config
+++ b/docker/common-config
@@ -40,7 +40,7 @@ real_ip_recursive on;
 
 send_timeout  300s;
 sendfile      on;
-server_tokens on;
+server_tokens off;
 
 tcp_nopush  on;
 tcp_nodelay on;
@@ -48,6 +48,31 @@ tcp_nodelay on;
 location /health {
   default_type text/html;
   return 200 "<!DOCTYPE html><h1>Not too bad!</h1>\n";
+  access_log off;
+}
+
+location ^~ /.well-known/ {
+  return 404;
+  access_log off;
+}
+
+location = /favicon.ico {
+  return 404;
+  access_log off;
+}
+
+location = /apple-touch-icon.png {
+  return 404;
+  access_log off;
+}
+
+location = /apple-touch-icon-precomposed.png {
+  return 404;
+  access_log off;
+}
+
+location ~* /\. {
+  return 404;
   access_log off;
 }
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       API_PREFIX: "/api/"
       OAI_PREFIX: "/oai"
       PROXY_TYPE: "single"
+      PUBLIC_ENABLED: "true"
       PUBLIC_NAME: "archivesspace-ex-complete.lyrtech.org"
       PUBLIC_PREFIX: "/"
       PUI_IPS_ALLOWED: "allow 0.0.0.0/0"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env sh
 set -eu
 
-if [ "$PUBLIC_PREFIX" != "/" ]; then
+# Only redirect to the public prefix when the PUI is actually enabled. When it
+# is disabled the prefix is still forced to /public/, but root must serve staff,
+# so emitting these rewrites would hijack / to a dead /public/ upstream.
+if [ "$PUBLIC_ENABLED" = "true" ] && [ "$PUBLIC_PREFIX" != "/" ]; then
   REDIRECT_BLOCK="rewrite ^${PUBLIC_PREFIX%/}$ $PUBLIC_PREFIX permanent;"
   ROOT_REDIRECT_BLOCK="rewrite ^/$ $PUBLIC_PREFIX permanent;"
 else

--- a/docker/templates/multi-domain.conf.template
+++ b/docker/templates/multi-domain.conf.template
@@ -1,4 +1,7 @@
 limit_req_zone $binary_remote_addr zone=waypoints_limit:16m rate=23r/s;
+limit_req_zone $binary_remote_addr zone=login_limit:10m rate=5r/m;
+limit_req_zone $binary_remote_addr zone=pdf_limit:10m rate=2r/m;
+limit_req_zone $binary_remote_addr zone=search_limit:10m rate=30r/m;
 
 upstream app_api {
   server ${UPSTREAM_HOST}:8089;
@@ -23,6 +26,10 @@ server {
   set_real_ip_from ${REAL_IP_CIDR};
   include /etc/nginx/common-config;
 
+  if ($query_string ~* ".{1500}") {
+    return 400;
+  }
+
   location ${PUBLIC_PREFIX} {
     ${PUI_IPS_ALLOWED};
     deny all;
@@ -31,6 +38,33 @@ server {
 
   location ~* (wp-admin|wp-includes|wp-content|xmlrpc\.php|wp-login\.php|wp-config\.php|wp-cron\.php|wp-trackback\.php|wp-comments-post\.php|wp-links-opml\.php) {
       deny all;
+  }
+
+  # Block file extensions ArchivesSpace never serves
+  location ~* \.(php|asp|aspx|cgi)$ {
+    return 404;
+  }
+
+  # Block known scanner and exploit paths
+  location ~* ^/(webdav|sling|adminer|apisix|tcpdf|jkstatus|actuator|console|manager|solr|h2-console|jolokia|api/jsonws|_vti_bin|_vti_pvt|_vti_aut|_vti_inf) {
+    return 403;
+  }
+
+  # Block JSF and Java path traversal attempts
+  location ~* (javax\.faces\.resource|WEB-INF|META-INF) {
+    return 403;
+  }
+
+  # Rate-limit search (hits Solr; targeted heavily by injection probes)
+  location ~* ^/(advanced_)?search {
+    limit_req zone=search_limit burst=20 nodelay;
+    proxy_pass http://app_public;
+  }
+
+  # Rate-limit PDF generation (CPU-intensive endpoint)
+  location ~ ^/repositories/[0-9]+/resources/[0-9]+/pdf$ {
+    limit_req zone=pdf_limit burst=4 nodelay;
+    proxy_pass http://app_public;
   }
 
   location ~ ^/repositories/\d+/resources/\d+/infinite/waypoints {
@@ -49,6 +83,33 @@ server {
   server_name ${STAFF_NAME};
   set_real_ip_from ${REAL_IP_CIDR};
   include /etc/nginx/common-config;
+
+  if ($query_string ~* ".{1500}") {
+    return 400;
+  }
+
+  # Block file extensions ArchivesSpace never serves
+  location ~* \.(php|asp|aspx|cgi)$ {
+    return 404;
+  }
+
+  # Block known scanner and exploit paths
+  location ~* ^/(webdav|sling|adminer|apisix|tcpdf|jkstatus|actuator|console|manager|solr|h2-console|jolokia|api/jsonws|_vti_bin|_vti_pvt|_vti_aut|_vti_inf) {
+    return 403;
+  }
+
+  # Block JSF and Java path traversal attempts
+  location ~* (javax\.faces\.resource|WEB-INF|META-INF) {
+    return 403;
+  }
+
+  # Rate-limit staff login to slow brute force attempts
+  location = /staff/login {
+    limit_req zone=login_limit burst=10 nodelay;
+    ${SUI_IPS_ALLOWED};
+    deny all;
+    proxy_pass http://app_staff;
+  }
 
   location ${STAFF_PREFIX} {
     ${SUI_IPS_ALLOWED};

--- a/docker/templates/multi-domain.conf.template
+++ b/docker/templates/multi-domain.conf.template
@@ -26,10 +26,6 @@ server {
   set_real_ip_from ${REAL_IP_CIDR};
   include /etc/nginx/common-config;
 
-  if ($query_string ~* ".{1500}") {
-    return 400;
-  }
-
   location ${PUBLIC_PREFIX} {
     ${PUI_IPS_ALLOWED};
     deny all;
@@ -41,12 +37,12 @@ server {
   }
 
   # Block file extensions ArchivesSpace never serves
-  location ~* \.(php|asp|aspx|cgi)$ {
+  location ~* \.(php|asp|aspx|cgi|action|dll|sh|bat)$ {
     return 404;
   }
 
   # Block known scanner and exploit paths
-  location ~* ^/(webdav|sling|adminer|apisix|tcpdf|jkstatus|actuator|console|manager|solr|h2-console|jolokia|api/jsonws|_vti_bin|_vti_pvt|_vti_aut|_vti_inf) {
+  location ~* ^/(webdav|sling|adminer|apisix|tcpdf|jkstatus|actuator|console|manager|solr|h2-console|jolokia|api/jsonws|_vti_bin|_vti_pvt|_vti_aut|_vti_inf|heapdump|graphql|geoserver|wls-wsat|autodiscover) {
     return 403;
   }
 
@@ -84,17 +80,13 @@ server {
   set_real_ip_from ${REAL_IP_CIDR};
   include /etc/nginx/common-config;
 
-  if ($query_string ~* ".{1500}") {
-    return 400;
-  }
-
   # Block file extensions ArchivesSpace never serves
-  location ~* \.(php|asp|aspx|cgi)$ {
+  location ~* \.(php|asp|aspx|cgi|action|dll|sh|bat)$ {
     return 404;
   }
 
   # Block known scanner and exploit paths
-  location ~* ^/(webdav|sling|adminer|apisix|tcpdf|jkstatus|actuator|console|manager|solr|h2-console|jolokia|api/jsonws|_vti_bin|_vti_pvt|_vti_aut|_vti_inf) {
+  location ~* ^/(webdav|sling|adminer|apisix|tcpdf|jkstatus|actuator|console|manager|solr|h2-console|jolokia|api/jsonws|_vti_bin|_vti_pvt|_vti_aut|_vti_inf|heapdump|graphql|geoserver|wls-wsat|autodiscover) {
     return 403;
   }
 

--- a/docker/templates/single-domain.conf.template
+++ b/docker/templates/single-domain.conf.template
@@ -26,10 +26,6 @@ server {
   set_real_ip_from ${REAL_IP_CIDR};
   include /etc/nginx/common-config;
 
-  if ($query_string ~* ".{1500}") {
-    return 400;
-  }
-
   location ${PUBLIC_PREFIX} {
     ${PUI_IPS_ALLOWED};
     deny all;
@@ -41,12 +37,12 @@ server {
   }
 
   # Block file extensions ArchivesSpace never serves
-  location ~* \.(php|asp|aspx|cgi)$ {
+  location ~* \.(php|asp|aspx|cgi|action|dll|sh|bat)$ {
     return 404;
   }
 
   # Block known scanner and exploit paths
-  location ~* ^/(webdav|sling|adminer|apisix|tcpdf|jkstatus|actuator|console|manager|solr|h2-console|jolokia|api/jsonws|_vti_bin|_vti_pvt|_vti_aut|_vti_inf) {
+  location ~* ^/(webdav|sling|adminer|apisix|tcpdf|jkstatus|actuator|console|manager|solr|h2-console|jolokia|api/jsonws|_vti_bin|_vti_pvt|_vti_aut|_vti_inf|heapdump|graphql|geoserver|wls-wsat|autodiscover) {
     return 403;
   }
 

--- a/docker/templates/single-domain.conf.template
+++ b/docker/templates/single-domain.conf.template
@@ -59,14 +59,16 @@ server {
     proxy_pass http://app_staff;
   }
 
-  # Rate-limit search (hits Solr; targeted heavily by injection probes)
-  location ~* ^/(advanced_)?search {
+  # Rate-limit public search (hits Solr; targeted heavily by injection probes)
+  # Anchored to the public prefix so staff routes (e.g. the linker's
+  # /search.json) are not captured and misrouted to app_public.
+  location ~* ^${PUBLIC_PREFIX}(advanced_)?search {
     limit_req zone=search_limit burst=20 nodelay;
     proxy_pass http://app_public;
   }
 
-  # Rate-limit PDF generation (CPU-intensive endpoint)
-  location ~ ^/repositories/[0-9]+/resources/[0-9]+/pdf$ {
+  # Rate-limit public PDF generation (CPU-intensive endpoint)
+  location ~ ^${PUBLIC_PREFIX}repositories/[0-9]+/resources/[0-9]+/pdf$ {
     limit_req zone=pdf_limit burst=4 nodelay;
     proxy_pass http://app_public;
   }

--- a/docker/templates/single-domain.conf.template
+++ b/docker/templates/single-domain.conf.template
@@ -1,4 +1,7 @@
 limit_req_zone $binary_remote_addr zone=waypoints_limit:16m rate=23r/s;
+limit_req_zone $binary_remote_addr zone=login_limit:10m rate=5r/m;
+limit_req_zone $binary_remote_addr zone=pdf_limit:10m rate=2r/m;
+limit_req_zone $binary_remote_addr zone=search_limit:10m rate=30r/m;
 
 upstream app_api {
   server ${UPSTREAM_HOST}:8089;
@@ -23,6 +26,10 @@ server {
   set_real_ip_from ${REAL_IP_CIDR};
   include /etc/nginx/common-config;
 
+  if ($query_string ~* ".{1500}") {
+    return 400;
+  }
+
   location ${PUBLIC_PREFIX} {
     ${PUI_IPS_ALLOWED};
     deny all;
@@ -31,6 +38,41 @@ server {
 
   location ~* (wp-admin|wp-includes|wp-content|xmlrpc\.php|wp-login\.php|wp-config\.php|wp-cron\.php|wp-trackback\.php|wp-comments-post\.php|wp-links-opml\.php) {
       deny all;
+  }
+
+  # Block file extensions ArchivesSpace never serves
+  location ~* \.(php|asp|aspx|cgi)$ {
+    return 404;
+  }
+
+  # Block known scanner and exploit paths
+  location ~* ^/(webdav|sling|adminer|apisix|tcpdf|jkstatus|actuator|console|manager|solr|h2-console|jolokia|api/jsonws|_vti_bin|_vti_pvt|_vti_aut|_vti_inf) {
+    return 403;
+  }
+
+  # Block JSF and Java path traversal attempts
+  location ~* (javax\.faces\.resource|WEB-INF|META-INF) {
+    return 403;
+  }
+
+  # Rate-limit staff login to slow brute force attempts
+  location = /staff/login {
+    limit_req zone=login_limit burst=10 nodelay;
+    ${SUI_IPS_ALLOWED};
+    deny all;
+    proxy_pass http://app_staff;
+  }
+
+  # Rate-limit search (hits Solr; targeted heavily by injection probes)
+  location ~* ^/(advanced_)?search {
+    limit_req zone=search_limit burst=20 nodelay;
+    proxy_pass http://app_public;
+  }
+
+  # Rate-limit PDF generation (CPU-intensive endpoint)
+  location ~ ^/repositories/[0-9]+/resources/[0-9]+/pdf$ {
+    limit_req zone=pdf_limit burst=4 nodelay;
+    proxy_pass http://app_public;
   }
 
   location ~ ^/repositories/\d+/resources/\d+/infinite/waypoints {

--- a/task-definition/archivesspace.json.tpl
+++ b/task-definition/archivesspace.json.tpl
@@ -53,6 +53,10 @@
         "value": "${proxy_type}"
       },
       {
+        "name": "PUBLIC_ENABLED",
+        "value": "${public_enabled}"
+      },
+      {
         "name": "PUBLIC_NAME",
         "value": "${public_hostname}"
       },


### PR DESCRIPTION
@mark-cooper Temple was getting attacked so I ended up coming up with some ideas based on that and other sites

- server_tokens off  probably doesn't matter
- Reject query strings over 1,500 characters saw on Temple I'm not sure how common
- Rate limiting: staff login (5r/m, burst 10), search + advanced_search (30r/m, burst 20), PDF generation (2r/m, burst 4), waypoints (23r/s, burst 100). 
- Block WordPress etc paths, .php/.asp/.aspx/.cgi extensions, JSF/Java traversal paths (WEB-INF, META-INF, javax.faces.resource)
- Block scanner/exploit paths: webdav, sling, adminer, apisix, actuator, console, manager, solr, h2-console, jolokia, api/jsonws, _vti_*
- nginx 404s: favicon.ico, apple-touch-icon*.png, /.well-known/*, all dot-files (/.anything) This stops the 404s in the logs like we were talking about the other day

Tested on qa only so far.

```
docker compose build --no-cache && docker tag docker-aspace-proxy lyrasis/aspace-proxy:sectest && docker push lyrasis/aspace-proxy:sectest
```